### PR TITLE
feat(i18n): localize class section label in Thai and English

### DIFF
--- a/components/class.tsx
+++ b/components/class.tsx
@@ -42,7 +42,7 @@ export function Class({ classInfo, assignments }: ClassProps) {
                 </div>
                 <hr className="my-[0.4rem]" />
                 <div className="text-[11px] text-muted-foreground">
-                  Section {classInfo.section}
+                  {t("section")} {classInfo.section}
                 </div>
               </div>
             </div>

--- a/lib/i18n.test.ts
+++ b/lib/i18n.test.ts
@@ -50,6 +50,8 @@ describe("i18n", () => {
       );
       expect(translate("cleared", "en")).toBe("Cleared!");
       expect(translate("cleared", "th")).toBe("ล้างแล้ว!");
+      expect(translate("section", "en")).toBe("Section");
+      expect(translate("section", "th")).toBe("กลุ่มที่");
       expect(translate("sponsor", "en")).toBe("Sponsor");
       expect(translate("sponsor", "th")).toBe("สนับสนุน");
     });

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -30,6 +30,7 @@ export type TranslationKey =
   | "hidden_items"
   | "clear_all"
   | "class"
+  | "section"
   | "no_assignments"
   | "no_assignments_desc"
   | "done_not_submitted_yet"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -23,6 +23,7 @@ hidden: Hidden
 hidden_items: Hidden Items
 clear_all: Clear All
 class: Class
+section: Section
 no_assignments: No Assignments
 no_assignments_desc: Congratulations! You have no assignments to do.
 done_not_submitted_yet: Done (Not Submitted Yet)

--- a/locales/th.yml
+++ b/locales/th.yml
@@ -23,6 +23,7 @@ hidden: ที่ซ่อนไว้
 hidden_items: รายการที่ซ่อนไว้
 clear_all: ล้างทั้งหมด
 class: ชั้นเรียน
+section: กลุ่มที่
 no_assignments: ไม่มีการบ้าน
 no_assignments_desc: ยินดีด้วย! คุณไม่มีการบ้านที่ต้องทำ
 done_not_submitted_yet: ทำแล้วแต่ยังไม่ได้ส่ง


### PR DESCRIPTION
## Summary
- Localize class section label in `components/class.tsx` using `useI18n` hook (`{t("section")} {classInfo.section}`)
- Add `section: Section` to `locales/en.yml`
- Add `section: กลุ่มที่` to `locales/th.yml`
- Add `"section"` key to `TranslationKey` union in `lib/i18n.ts`
- Add translation unit tests for `section` key in `lib/i18n.test.ts`

## Testing
- `pnpm test` (vitest unit tests including `lib/i18n.test.ts`)
- `tsc --noEmit` (TypeScript typecheck)
- `pnpm dlx ultracite check` (formatting and linting)
